### PR TITLE
feat: add Notification Route

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient
 from src.routes import drafts
-from src.routes import facebook, webhook
+from src.routes import facebook, webhook, notification
 from src.helpers.config import get_Settings
 app = FastAPI()
 
@@ -16,5 +16,6 @@ async def shutdown_db_client():
     app.mongo_conn.close()
 
 app.include_router(facebook.facebook_router)
-# app.include_router(drafts.draft_router)
-# app.include_router(webhook.webhook_router)
+app.include_router(drafts.draft_router)
+app.include_router(webhook.webhook_router)
+app.include_router(notification.notification_route)

--- a/src/models/NotificationModel.py
+++ b/src/models/NotificationModel.py
@@ -4,7 +4,7 @@ from pymongo import DESCENDING
 from typing import List, Optional
 from src.models.db_schemas.Notification import Notification
 from src.models.BaseModel import BaseModel
-from src.models.enums import DBEnums
+from src.models.enums.DBEnums import DBEnums
 
 
 class NotificationModel(BaseModel):
@@ -63,17 +63,19 @@ class NotificationModel(BaseModel):
 
     async def create_notification(self, notification: Notification) -> Notification:
         """
-        Insert a new notification document.
+        Insert a new notification document into the database.
 
         Args:
             notification (Notification): The notification object to insert.
 
         Returns:
-            str: The ID of the inserted notification.
+            Notification: The inserted notification object with its generated ID.
         """
-        notif_dict = notification.dict(by_alias=True, exclude_none=True)
+        notif_dict = notification.model_dump(by_alias=True, exclude_none=True)
         result = await self.collection.insert_one(notif_dict)
+        notification.id = str(result.inserted_id)
         return notification
+
 
     async def get_by_id(self, notif_id: str) -> Optional[Notification]:
         """
@@ -100,7 +102,7 @@ class NotificationModel(BaseModel):
             List[Notification]: A list of user notifications.
         """
         cursor = (
-            self.collection.find({"user_id": ObjectId(user_id)})
+            self.collection.find({"user_id": user_id})
             .sort("createdAt", DESCENDING)
             .limit(limit)
         )

--- a/src/models/PostModel.py
+++ b/src/models/PostModel.py
@@ -198,12 +198,12 @@ class PostModel(BaseModel):
             posts.append(Post(**doc))
         return posts
 
-    async def list_rejected_posts_by_user_id(self, user_id: ObjectId, limit: int = 10, skip: int = 0) -> List[Post]:
+    async def list_rejected_posts_by_user_id(self, user_id: str, limit: int = 10, skip: int = 0) -> List[Post]:
         """
         Retrieve all REJECTED posts created by a specific user with pagination support.
 
         Args:
-            user_id (ObjectId): The ObjectId of the user whose rejected posts are to be retrieved.
+            user_id (str): User ID.
             limit (int, optional): Maximum number of posts to return. Defaults to 10.
             skip (int, optional): Number of posts to skip. Defaults to 0.
 
@@ -211,7 +211,7 @@ class PostModel(BaseModel):
             List[Post]: A list of Post objects with status REJECTED created by the given user.
         """
         cursor = self.collection.find({
-            "user_id": ObjectId(user_id),
+            "user_id": user_id,
             "status": PostStatus.REJECTED
         }).skip(skip).limit(limit)
         posts = []
@@ -219,12 +219,12 @@ class PostModel(BaseModel):
             posts.append(Post(**doc))
         return posts
 
-    async def list_accepted_posts_by_user_id(self, user_id: ObjectId, limit: int = 10, skip: int = 0) -> List[Post]:
+    async def list_accepted_posts_by_user_id(self, user_id: str, limit: int = 10, skip: int = 0) -> List[Post]:
         """
         Retrieve all ACCEPTED posts created by a specific user with pagination support.
 
         Args:
-            user_id (ObjectId): The ObjectId of the user whose accepted posts are to be retrieved.
+            user_id (str): User ID.
             limit (int, optional): Maximum number of posts to return. Defaults to 10.
             skip (int, optional): Number of posts to skip. Defaults to 0.
 
@@ -232,7 +232,7 @@ class PostModel(BaseModel):
             List[Post]: A list of Post objects with status ACCEPTED created by the given user.
         """
         cursor = self.collection.find({
-            "user_id": ObjectId(user_id),
+            "user_id": user_id,
             "status": PostStatus.ACCEPTED
         }).skip(skip).limit(limit)
         posts = []
@@ -240,12 +240,12 @@ class PostModel(BaseModel):
             posts.append(Post(**doc))
         return posts
     
-    async def list_draft_posts_by_user_id(self, user_id: ObjectId, limit: int = 10, skip: int = 0) -> List[Post]:
+    async def list_draft_posts_by_user_id(self, user_id: str, limit: int = 10, skip: int = 0) -> List[Post]:
         """
         Retrieve all DRAFT posts created by a specific user with pagination support.
 
         Args:
-            user_id (ObjectId): The ObjectId of the user whose accepted posts are to be retrieved.
+            user_id : the user ID.
             limit (int, optional): Maximum number of posts to return. Defaults to 10.
             skip (int, optional): Number of posts to skip. Defaults to 0.
 
@@ -253,7 +253,7 @@ class PostModel(BaseModel):
             List[Post]: A list of Post objects with status ACCEPTED created by the given user.
         """
         cursor = self.collection.find({
-            "user_id": ObjectId(user_id),
+            "user_id": user_id,
             "status": PostStatus.DRAFT
         }).skip(skip).limit(limit)
         posts = []

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,4 +2,4 @@ from .schemas import InteractionsResponse
 from .schemas import facebookSchemas
 from .schemas import CompetitorRequest
 from .schemas import CompetitorSummary
-from controllers.analytics import AnalyticsController
+from ..controllers.analytics import AnalyticsController

--- a/src/models/db_schemas/Notification.py
+++ b/src/models/db_schemas/Notification.py
@@ -1,35 +1,35 @@
-from typing import Optional, List
-from pydantic import BaseModel, Field, ConfigDict, field_validator
-from bson import ObjectId
+from typing import Optional, Annotated
+from pydantic import BaseModel, Field, ConfigDict, BeforeValidator
 from datetime import datetime, timezone
 
+PyObjectId = Annotated[str, BeforeValidator(str)]
+
 class Notification(BaseModel):
-    id: Optional[ObjectId] = Field(None, alias="_id")
-
-    title: str = Field(..., min_length= 10, max_length=100, description="title of the recommendation filled by Ai agent")
-
+    id: Optional[PyObjectId] = Field(None, alias="_id")
+    title: str = Field(..., min_length=10, max_length=100, description="Title of the recommendation filled by AI agent")
     content: str = Field(..., min_length=10)
-
     seen: bool = Field(default=False)
-
     createdAt: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    user_id: PyObjectId
 
-    user_id: ObjectId
-
-
-    @field_validator('id', mode="after")
-    def validate_post_id(cls, value):
-        if not isinstance(value, ObjectId):
-            raise ValueError("Notification_id must be a valid ObjectId")
-        return value
-    
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
+    model_config = ConfigDict(
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+        json_schema_extra={
+            "example": {
+                "_id": "66fe9e7fbd12f8f9c9f3e3d1",
+                "title": "New AI Recommendation",
+                "content": "We found a great new resource for you.",
+                "seen": False,
+                "createdAt": "2025-10-05T12:30:00Z",
+                "user_id": "66fe9e7fbd12f8f9c9f3e3d2"
+            }
+        }
+    )
 
     @classmethod
     def get_indexes(cls):
         return [
             {"key": [("user_id", 1)], "name": "user_index", "unique": False},
-            {"key":[("createdAt", -1)], "name":"createdAt", "unique": False}
+            {"key": [("createdAt", -1)], "name": "createdAt", "unique": False},
         ]

--- a/src/models/db_schemas/Post.py
+++ b/src/models/db_schemas/Post.py
@@ -1,11 +1,13 @@
-from pydantic import BaseModel, Field, field_validator, ConfigDict
-from typing import Optional
+from pydantic import BaseModel, Field, field_validator, ConfigDict, BeforeValidator
+from typing import Optional, Annotated
 from bson.objectid import ObjectId
 from datetime import datetime
 from ..enums.PostEnums import PostStatus
+
+PyObjectId = Annotated[str, BeforeValidator(str)]
 class Post(BaseModel):
     """Schema for a Post document in the database."""
-    id : Optional[ObjectId] = Field(None, alias="_id")
+    id : Optional[PyObjectId] = Field(None, alias="_id")
     userFeedback: float = Field(
         default=0.0,
         ge=0.0,
@@ -27,15 +29,27 @@ class Post(BaseModel):
         description="The status of the post, one of: DRAFT, ACCEPTED, or REJECTED."
     )
 
-    user_id: ObjectId
+    user_id: PyObjectId
     
-    @field_validator('id', mode="after")
-    def validate_post_id(cls, value):
-        if not isinstance(value, ObjectId):
-            raise ValueError("post_id must be a valid ObjectId")
-        return value
-    
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+        json_schema_extra={
+            "example": {
+                "_id": "66fe9e7fbd12f8f9c9f3e3a1",
+                "title": "AI in Healthcare: Opportunities and Challenges",
+                "content": "Artificial Intelligence is transforming the healthcare industry by improving diagnostics, treatment recommendations, and patient outcomes. However, challenges remain in terms of data privacy and interpretability of AI models...",
+                "userFeedback": 4.7,
+                "comments": [
+                    "This is an insightful post!",
+                    "AI ethics should be discussed more here."
+                ],
+                "status": "DRAFT",
+                "createdAt": "2025-10-05T14:00:00Z",
+                "user_id": "66fe9e7fbd12f8f9c9f3e3d2"
+            }
+        }
+        )
     
     @classmethod
     def get_indexes(cls):

--- a/src/models/enums/ResponseSignal.py
+++ b/src/models/enums/ResponseSignal.py
@@ -13,3 +13,7 @@ class ResponseSignal(Enum):
     DRAFT_NOT_FOUND="Draft not found"
     ACCEPTED_POST_NOT_FOUND= "No accepted posts found"
     REJECTED_POST_NOT_FOUND= "No rejected posts found"
+
+    INVALID_USER_ID ="Invalid user_id format"
+    FAILED_TO_MARK_AS_READ = "Failed to mark notification as read"
+    NOTIFICATION_NOT_FOUND = "Notification not found."

--- a/src/models/schemas/DraftSChemas.py
+++ b/src/models/schemas/DraftSChemas.py
@@ -1,28 +1,8 @@
-from pydantic import BaseModel, Field, field_validator, ConfigDict
-from typing import Optional, List
-from datetime import datetime
-from bson import ObjectId
+from pydantic import BaseModel, Field
 from src.models.enums.PostEnums import PostStatus
 
 
 # ---------- RESPONSE SCHEMAS ----------
-class PostResponse(BaseModel):
-    id: str
-    title: str
-    content: str
-    createdAt: datetime
-    status: PostStatus
-    comments: List[str] = []
-    userFeedback: float
-    user_id:str
-
-    @field_validator("id", "user_id", mode="before")
-    def convert_objectids(cls, v):
-        if isinstance(v, ObjectId):
-            return str(v)
-        return v
-
-
 class EditPostResponse(BaseModel):
     id: str
     title: str

--- a/src/models/schemas/NotificationSchemas.py
+++ b/src/models/schemas/NotificationSchemas.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+class SendNotificationRequest(BaseModel):
+    user_id: str
+
+    title: str = Field(..., min_length= 10, max_length=100, description="title of the recommendation filled by Ai agent")
+
+    content: str = Field(..., min_length=10)
+
+class MarkReadRequest(BaseModel):
+    notification_id: str
+
+
+class MarkReadResponse(BaseModel):
+    matched_count: int
+    modified_count: int

--- a/src/models/schemas/__init__.py
+++ b/src/models/schemas/__init__.py
@@ -1,3 +1,3 @@
-from CompetitorSummary import CompetitorSummary
-from CompetitorRequest import CompetitorRequest
-from InteractionsResponse import InteractionResponse
+from .CompetitorSummary import CompetitorSummary
+from .CompetitorRequest import CompetitorRequest
+from .InteractionsResponse import InteractionResponse

--- a/src/routes/notification.py
+++ b/src/routes/notification.py
@@ -1,0 +1,106 @@
+from fastapi import APIRouter, status, Request, Depends, HTTPException, Query
+from src.models.NotificationModel import NotificationModel
+from src.models.db_schemas.Notification import Notification
+from bson import ObjectId, errors
+from typing import List
+from src.models.enums.ResponseSignal import ResponseSignal
+from src.models.schemas.NotificationSchemas import (
+    MarkReadRequest,
+    SendNotificationRequest,
+    MarkReadResponse,
+)
+notification_route = APIRouter(prefix="/notification", tags=["Notification"])
+
+async def get_notification_model(request: Request) -> NotificationModel:
+    """
+    Dependency to get a NotificationModel instance from the app's database client.
+    """
+    db_client = request.app.db_client
+    return await NotificationModel.create_instance(db_client)
+
+
+@notification_route.get(
+    "/get_all_user_notifications",
+    status_code=status.HTTP_200_OK,
+    response_model=List[Notification]
+)
+async def get_all_user_notification(
+    user_id : str = Query(description="User ID"),
+    limit: int = Query(50, description="Maximum number of notifications to fetch. Defaults to 50"),
+    notification_model: NotificationModel = Depends(get_notification_model)
+) -> List[Notification]:
+    try:
+        result = await notification_model.get_user_notifications(user_id, limit=limit)
+        if not result:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ResponseSignal.NOTIFICATION_NOT_FOUND.value
+            )
+        return result
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch notifications: {str(e)}"
+        )
+
+
+@notification_route.put(
+    "/mark_seen",
+    response_model=MarkReadResponse,
+    status_code=status.HTTP_200_OK
+)
+async def mark_read(
+    req: MarkReadRequest,
+    notification_model: NotificationModel = Depends(get_notification_model)
+) -> MarkReadResponse:
+    try:
+        result = await notification_model.mark_as_seen(req.notification_id)
+        if result.get("matched_count", 0) == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ResponseSignal.NOTIFICATION_NOT_FOUND.value
+            )
+        return MarkReadResponse(
+            matched_count=result["matched_count"],
+            modified_count=result["modified_count"]
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ResponseSignal.FAILED_TO_MARK_AS_READ.value
+        )
+
+
+@notification_route.post(
+    "/send",
+    response_model=Notification,
+    status_code=status.HTTP_201_CREATED
+)
+async def send_notification(
+    req: SendNotificationRequest,
+    notification_model: NotificationModel = Depends(get_notification_model)
+) -> Notification:
+    try:
+        # Validate user_id
+        try:
+            user_obj_id = ObjectId(req.user_id)
+        except errors.InvalidId:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ResponseSignal.INVALID_USER_ID.value
+            )
+
+        notification = Notification(
+            title=req.title,
+            content=req.content,
+            user_id=user_obj_id
+        )
+        result = await notification_model.create_notification(notification=notification)
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to send notification: {str(e)}"
+        )


### PR DESCRIPTION
### Notification Route
Added a new **Notification route** with the following endpoints:
- `GET /notifications` – Retrieve notifications  
- `POST /notifications/send` – Send a new notification  
- `PATCH /notifications/mark-as-seen` – Mark notifications as seen  

### Draft & Notification Module Improvements
- Introduced **`PyObjectId`** to handle automatic conversion between `ObjectId` and string types in both **Draft** and **Notification** database schemas.  
- Updated all related code to ensure compatibility with this change.  
- Modified the draft endpoint to return the **`Post` schema** directly instead of using a separate response model, improving efficiency and reducing redundancy.
